### PR TITLE
Fix cache error checking

### DIFF
--- a/src/snapchat.php
+++ b/src/snapchat.php
@@ -257,7 +257,9 @@ class Snapchat extends SnapchatAgent {
 
 		if (!empty($result->updates_response)) {
 			$this->auth_token = $result->updates_response->auth_token;
-			$this->cache->set('updates', $result->updates_response);
+			if (isset($this->cache)) {
+				$this->cache->set('updates', $result->updates_response);
+			}
 			return $result->updates_response;
 		}
 
@@ -338,7 +340,7 @@ class Snapchat extends SnapchatAgent {
 			)
 		);
 
-		if (!empty($result->stories_response)) {
+		if (isset($this->cache) && !empty($result->stories_response)) {
 			$this->cache->set('stories', $result->stories_response);
 		}
 		else {


### PR DESCRIPTION
This adds a condition to check if the Snapchat::$cache object is set before using it. If it is not set, it issues the request normally and does not cache the response, if successful.

The second commit adds a check before setting the cache as well. The request should not normally complete successfully when $cache is not set, but in the future you might want to add the option to not to set the cache object in the constructor/login so requests are never cached, and this would be necessary.
