### PR TITLE
Update snapchat_agent.php

### DIFF
--- a/src/snapchat_agent.php
+++ b/src/snapchat_agent.php
@@ -190,7 +190,7 @@ abstract class SnapchatAgent {
 	 */
 	function isImage($data) {
 		// Check for a JPG header.
-		return ($data[0] == chr(0xFF) && $data[1] == chr(0xD8))
+		return ($data[0] == chr(0xFF) && $data[1] == chr(0xD8));
 	}
 	
 	/**


### PR DESCRIPTION
separate isMedia into isImage and isVideo functions which can be used independently to identify if the media is an image or a video. The isMedia function relies on the individual functions and allows a consumer of this class to use these headers which are much more accurate than the media_type attribute which I have (anecdotally) found to be unreliable.

You seem to prefer the more verbose:

``` php
if (test) {
  return TRUE;
}
return FALSE;
```

pattern, I didn't look very hard for contribution guidelines so I went with the a condensed style. Let me know if you have a strong preference for the other style.
