### PR TITLE
Replace curl cacert error magic number with equivalent constant

### DIFF
--- a/src/snapchat_agent.php
+++ b/src/snapchat_agent.php
@@ -307,7 +307,7 @@ abstract class SnapchatAgent {
 
 		// If cURL doesn't have a bundle of root certificates handy, we provide
 		// ours (see http://curl.haxx.se/docs/sslcerts.html).
-		if (curl_errno($ch) == 60) {
+		if (curl_errno($ch) == CURLE_SSL_CACERT) {
 			curl_setopt($ch, CURLOPT_CAINFO, dirname(__FILE__) . '/ca_bundle.crt');
 			$result = curl_exec($ch);
 		}


### PR DESCRIPTION
Because magic numbers are kinda gross.

60 -> CURLE_SSL_CACERT