### PR TITLE
Check for login before pulling from cache, resolving fatal errors

### DIFF
--- a/src/snapchat.php
+++ b/src/snapchat.php
@@ -230,16 +230,17 @@ class Snapchat extends SnapchatAgent {
 	 *   The data returned by the service or FALSE on failure.
 	 */
 	public function getUpdates($force = FALSE) {
+
+		// Make sure we're logged in and have a valid access token.
+		if (!$this->auth_token || !$this->username) {
+			return FALSE;
+		}
+
 		if (!$force) {
 			$result = $this->cache->get('updates');
 			if ($result) {
 				return $result;
 			}
-		}
-
-		// Make sure we're logged in and have a valid access token.
-		if (!$this->auth_token || !$this->username) {
-			return FALSE;
 		}
 
 		$timestamp = parent::timestamp();
@@ -312,17 +313,18 @@ class Snapchat extends SnapchatAgent {
 	 * @return mixed
 	 *   An array of stories or FALSE on failure.
 	 */
-	function getFriendStories($force = FALSE) {
+	public function getFriendStories($force = FALSE) {
+
+		// Make sure we're logged in and have a valid access token.
+		if (!$this->auth_token || !$this->username) {
+			return FALSE;
+		}
+
 		if (!$force) {
 			$result = $this->cache->get('stories');
 			if ($result) {
 				return $result;
 			}
-		}
-
-		// Make sure we're logged in and have a valid access token.
-		if (!$this->auth_token || !$this->username) {
-			return FALSE;
 		}
 
 		$timestamp = parent::timestamp();


### PR DESCRIPTION
Currently, if login fails and you try getSnaps() or any of the
other get functions, it will call getUpdates() which calls
$this->cache->get() before checking for a valid login.

As $this->cache is not populated until a valid login, this will
cause this sort of error:

```Fatal error: Call to a member function get() on a non-object in /homepages/15/d419114431/htdocs/bobink/snapchat/src/snapchat.php on line 234```

This change modifies the code to perform the login check before
pulling from cache, solving the fatal errors.